### PR TITLE
fix artifact cleanup

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -204,7 +204,6 @@ if [ "$should_export" = true ] ; then
         rm -rf "$unarchived_path"
     fi
 
-    rm -rf "$download_path"
     rm -rf "$download_folder"
 fi
 


### PR DESCRIPTION
Only clear the download folder and not the download path.
2 possible cases:

*  Export path is set.
download path is overwritten with export path. 
export path is provided by the user and should not be removed

* Export path is not set
download path is located in download folder and will be removed along with the folder

